### PR TITLE
Minor: change 'With' to lowercase

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
 	"128": "icon.png"
   },
   "manifest_version": 2,
-  "name": "Handle With",
+  "name": "Handle with",
   "options_ui": {
     "page": "options.html"
   },


### PR DESCRIPTION
Addon name  is used in menus, and capital letter in the second word is an eyesore : ) Maybe it's just me, but i think it's more consistent and aesthetically pleasing